### PR TITLE
Keep CheckboxStateChange fallback for expert mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 *bookmarkdupes-6.7:
 	Martin Väth <martin at mvath.de>:
+	- Keep CheckboxStateChange as fallback for expert mode activation
 	- Make CheckboxStateChange work on new browsers (use change event)
 
 *bookmarkdupes-6.6:

--- a/data/tab/dupes.js
+++ b/data/tab/dupes.js
@@ -2662,6 +2662,7 @@ function initMain() {
   }
   addButtonsBase();
   document.addEventListener("change", checkboxListener);
+  document.addEventListener("CheckboxStateChange", checkboxListener);
   document.addEventListener("click", clickListener);
   document.addEventListener("change", changeListener);
   compatible.browser.storage.onChanged.addListener(storageListener);


### PR DESCRIPTION
The expert mode checkbox may not activate reliably when only the standard change event is listened to.

This keeps the new change listener but also registers CheckboxStateChange as a fallback, preserving compatibility with browser/extension contexts where that event is still needed.