### PR TITLE
Guard duplicate checkbox events

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 *bookmarkdupes-6.7.1:
 	atik4242:
-	- Keep CheckboxStateChange as a fallback
+	- Keep CheckboxStateChange as a fallback, guarding against duplicate events
 
 *bookmarkdupes-6.7:
 	Martin Väth <martin at mvath.de>:

--- a/data/tab/dupes.js
+++ b/data/tab/dupes.js
@@ -2433,6 +2433,26 @@ function initMain() {
     }
   }
 
+  let lastCheckboxEvent;
+
+  function checkboxListenerOnce(event) {
+    if (event.target && event.target.type === "checkbox") {
+      const now = Date.now();
+      if (lastCheckboxEvent
+          && (lastCheckboxEvent.target === event.target)
+          && (lastCheckboxEvent.checked === event.target.checked)
+          && ((now - lastCheckboxEvent.time) < 50)) {
+        return;
+      }
+      lastCheckboxEvent = {
+        target: event.target,
+        checked: event.target.checked,
+        time: now
+      };
+    }
+    checkboxListener(event);
+  }
+
   function checkboxListener(event) {
     if (!event.target || !event.target.id) {
       return;
@@ -2661,8 +2681,8 @@ function initMain() {
     return;
   }
   addButtonsBase();
-  document.addEventListener("change", checkboxListener);
-  document.addEventListener("CheckboxStateChange", checkboxListener);
+  document.addEventListener("change", checkboxListenerOnce);
+  document.addEventListener("CheckboxStateChange", checkboxListenerOnce);
   document.addEventListener("click", clickListener);
   document.addEventListener("change", changeListener);
   compatible.browser.storage.onChanged.addListener(storageListener);


### PR DESCRIPTION
This adds a small guard around the checkbox event handler so that duplicate events for the same checkbox state are ignored.

This keeps both change and CheckboxStateChange registered, while avoiding double handling if a browser fires both events for the same checkbox action.